### PR TITLE
Fix the discussed issue

### DIFF
--- a/advanced_llm_apps/chat_with_X_tutorials/chat_with_llms/steps/conversation.stream.ts
+++ b/advanced_llm_apps/chat_with_X_tutorials/chat_with_llms/steps/conversation.stream.ts
@@ -1,4 +1,4 @@
-import { StreamConfig } from 'motia'
+import { StateStreamConfig } from 'motia'
 import { z } from 'zod'
 
 export const conversationSchema = z.object({
@@ -8,8 +8,8 @@ export const conversationSchema = z.object({
   timestamp: z.string(),
 })
 
-export const config: StreamConfig = {
+export const config: StateStreamConfig = {
   name: 'conversation',
   schema: conversationSchema,
-  baseConfig: { storageType: 'default' },
+  baseConfig: { storageType: 'state' },
 }


### PR DESCRIPTION
An issue was identified and fixed in `advanced_llm_apps/chat_with_X_tutorials/chat_with_llms/steps/conversation.stream.ts`. The file's configuration for the conversation stream was inconsistent with documentation and type definitions.

The following changes were made:
*   The import for `StreamConfig` was updated to `StateStreamConfig`.
*   The `config` object's type annotation was changed from `StreamConfig` to `StateStreamConfig`.
*   Within the `baseConfig`, `storageType: 'default'` was corrected to `storageType: 'state'`.

This ensures the implementation aligns with the `README.md` documentation and the `types.d.ts` definitions, which expect an `IStateStream`. The fix establishes proper state management for the conversation stream, allowing for correct real-time conversation updates.